### PR TITLE
add default HC value

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,7 +72,7 @@ services:
       MASTER_TOKEN: "fake-us-master-token"
       PG_TEST_DATA: 1
       CH_DEMO_DATA: 1
-      HC: ${HC:-1}
+      HC: ${HC:-0}
     ports:
       - "50500:80"
 
@@ -91,4 +91,4 @@ services:
       APP_INSTALLATION: "opensource"
       AUTH_POLICY: "disabled"
       NODE_EXTRA_CA_CERTS: "/usr/local/share/ca-certificates/cert.pem"
-      HC: ${HC:-1}
+      HC: ${HC:-0}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,7 +72,7 @@ services:
       MASTER_TOKEN: "fake-us-master-token"
       PG_TEST_DATA: 1
       CH_DEMO_DATA: 1
-      HC: ${HC}
+      HC: ${HC:-1}
     ports:
       - "50500:80"
 
@@ -91,4 +91,4 @@ services:
       APP_INSTALLATION: "opensource"
       AUTH_POLICY: "disabled"
       NODE_EXTRA_CA_CERTS: "/usr/local/share/ca-certificates/cert.pem"
-      HC: ${HC}
+      HC: ${HC:-1}


### PR DESCRIPTION
add default HC value to docker-compose file help for users on Windows system (HC=1 docker compose up - syntax not working from cmd shell)

I hereby agree to the terms of the CLA available at: [link](https://yandex.ru/legal/cla/?lang=en).