### PR TITLE
Add UI_PORT env variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2023-01-20
+- Add `UI_PORT` env param
+
 ## 2023-01-15
 - Add `docker-compose-dev.yml`
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ METADATA_POSTGRES_DSN_LIST="postgres://{user}:{password}@{host}:{port}/{database
 
 This command will launch all containers required to run DataLens and UI will be available on http://localhost:8080
 
+If you want to use a different port (e.g. `8081`), you can set it using the `UI_PORT` env variable:
+
+```bash
+UI_PORT=8081 docker compose up
+```
+
 <details>
       <summary>Notice on Highcharts usage</summary>
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -105,7 +105,7 @@ services:
     container_name: datalens-ui
     image: ghcr.io/datalens-tech/datalens-ui:0.1137.0
     ports:
-      - ${DATALENS_PORT:-8080}:80
+      - ${UI_PORT:-8080}:80
     depends_on:
       - us
       - control-api

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -105,7 +105,7 @@ services:
     container_name: datalens-ui
     image: ghcr.io/datalens-tech/datalens-ui:0.1137.0
     ports:
-      - 8080:80
+      - ${DATALENS_PORT:-8080}:80
     depends_on:
       - us
       - control-api

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,7 +96,7 @@ services:
     container_name: datalens-ui
     image: ghcr.io/datalens-tech/datalens-ui:0.1137.0
     ports:
-      - ${DATALENS_PORT:-8080}:80
+      - ${UI_PORT:-8080}:80
     depends_on:
       - us
       - control-api

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,7 +96,7 @@ services:
     container_name: datalens-ui
     image: ghcr.io/datalens-tech/datalens-ui:0.1137.0
     ports:
-      - 8080:80
+      - ${DATALENS_PORT:-8080}:80
     depends_on:
       - us
       - control-api

--- a/templates/docker-compose.j2
+++ b/templates/docker-compose.j2
@@ -105,7 +105,7 @@ services:
     container_name: datalens-ui
     image: ghcr.io/datalens-tech/datalens-ui:{{ uiVersion }}
     ports:
-      - ${DATALENS_PORT:-8080}:80
+      - ${UI_PORT:-8080}:80
     depends_on:
       - us
       - control-api

--- a/templates/docker-compose.j2
+++ b/templates/docker-compose.j2
@@ -105,7 +105,7 @@ services:
     container_name: datalens-ui
     image: ghcr.io/datalens-tech/datalens-ui:{{ uiVersion }}
     ports:
-      - 8080:80
+      - ${DATALENS_PORT:-8080}:80
     depends_on:
       - us
       - control-api


### PR DESCRIPTION
If you want to use a different port (e.g. `8081`), you can set it using the `UI_PORT` env variable:

```bash
UI_PORT=8081 docker compose up
```
