### PR TITLE
fix(helm): postgresql deployment for ext4 volumes with non-empty mount points

### DIFF
--- a/helm/templates/deployment-postgres.yaml
+++ b/helm/templates/deployment-postgres.yaml
@@ -24,6 +24,8 @@ spec:
         ports:
           - containerPort: 5432
         env:
+          - name: PGDATA
+            value: /var/lib/postgresql/data/pgdata
           - name: POSTGRES_USER
             value: {{ .Values.postgres.POSTGRES_USER }}
           - name: POSTGRES_DB_COMPENG


### PR DESCRIPTION
During deployment in the cluster, PostgreSQL initialization fails with the following error:

```
│ initdb: error: directory "/var/lib/postgresql/data" exists but is not empty                                                                                │
│ initdb: detail: It contains a lost+found directory, perhaps due to it being a mount point.                                                                 │
│ initdb: hint: Using a mount point directly as the data directory is not recommended.                                                                       │
│ Create a subdirectory under the mount point.
```

This happens because the /var/lib/postgresql/data directory is a mount point on ext4 volumes and contains the system-generated lost+found folder, which prevents initdb from running properly.

What was changed:

    Added PGDATA environment variable to explicitly point PostgreSQL to use /var/lib/postgresql/data/pgdata subdirectory as the data directory.

This change fixes the deployment issue by ensuring that the data directory is a dedicated subdirectory rather than the root of the mount point.